### PR TITLE
Fix: Issue #60: Github action executables couldn't run

### DIFF
--- a/.github/workflows/build_application.yml
+++ b/.github/workflows/build_application.yml
@@ -30,15 +30,12 @@ jobs:
       - name: Build application
         run: |
           "${GITHUB_WORKSPACE}/bin/bazel" build //src/main/java/decide/program:DECIDE
+          cd bazel-bin/src/main/java/decide/program
+          tar zcf DECIDE.tar.gz DECIDE DECIDE.jar DECIDE.runfiles
+          cd -
 
       - name: Upload DECIDE
         uses: actions/upload-artifact@v1
         with:
-          name: DECIDE
-          path: bazel-bin/src/main/java/decide/program/DECIDE
-
-      - name: Upload DECIDE.jar
-        uses: actions/upload-artifact@v1
-        with:
-          name: DECIDE.jar
-          path: bazel-bin/src/main/java/decide/program/DECIDE.jar
+          name: DECIDE.tar.gz
+          path: bazel-bin/src/main/java/decide/program/DECIDE.tar.gz


### PR DESCRIPTION
Deployment workflow now produce a tar archivec which contains the neccessary runfiles